### PR TITLE
Develop

### DIFF
--- a/AbstractApi.php
+++ b/AbstractApi.php
@@ -4,7 +4,7 @@ namespace Scion\GitHub;
 use Scion\File\Parser\Json as JsonParser;
 use Scion\Http\Client\Curl;
 use Scion\Http\Request;
-use Scion\Utils\String;
+use Scion\Utils\Strings;
 use Scion\Validator\Json as JsonValidator;
 
 abstract class AbstractApi {
@@ -131,7 +131,7 @@ abstract class AbstractApi {
 	 * Constructor
 	 */
 	public function __construct() {
-		$this->string        = new String();
+		$this->string        = new Strings();
 		$this->jsonValidator = new JsonValidator();
 	}
 
@@ -312,7 +312,7 @@ abstract class AbstractApi {
 
 	/**
 	 * Get string
-	 * @return \Scion\Utils\String
+	 * @return \Scion\Utils\Strings
 	 */
 	public function getString() {
 		return $this->string;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library works with cURL and provides all documented functionality as descri
 ## Quick Start
 ```php
 // Create a client object
-$client = new \Scion\Github\Client();
+$client = new \Scion\GitHub\Client();
 
 // Miscellaneous
 $miscellaneous = $client->getReceiver(\Scion\GitHub\Client::MISCELLANEOUS);

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
 		"scion/stdlib": "*",
 		"scion/utils": "*",
 		"scion/validator": "*"
+	},
+	"autoload": {
+		"psr-4": {"Scion\\GitHub\\": "./"}
 	}
 }


### PR DESCRIPTION
Add missing PSR-4 autoloader
Fix README error in Quick start section
"Utils\String" class has been renamed to "Utils\Strings"