### PR TITLE
Timing attack safe X-Hub-Signature validation

### DIFF
--- a/Event/Payload.php
+++ b/Event/Payload.php
@@ -160,7 +160,7 @@ class Payload implements EventInterface {
 				 */
 				list(, $hash) = explode('=', Headers::getInstance()->getHttpHeaders()['HTTP_X_HUB_SIGNATURE'], 2);
 
-				return $this->secret == $hash;
+				return hash_equals($this->secret, $hash);
 			}
 
 			throw new BadSignatureException('HTTP header "X-Hub-Signature" is missing.');


### PR DESCRIPTION
PHP 5.6.0 introduces a new hash_equals function to compare two hashes and mitigate timing attacks.

Reference: http://php.net/manual/en/migration56.new-features.php#migration56.new-features.hash-equals